### PR TITLE
store payment status

### DIFF
--- a/migrations/20151005183002-payment_status.js
+++ b/migrations/20151005183002-payment_status.js
@@ -1,0 +1,10 @@
+var dbm = global.dbm || require('db-migrate');
+var type = dbm.dataType;
+
+exports.up = function(db, callback) {
+  db.addColumn('participants','has_payed',{type:'boolean'}),callback();
+};
+
+exports.down = function(db, callback) {
+  db.removeColumn('participants','has_payed'),callback();
+};

--- a/routes/participants.js
+++ b/routes/participants.js
@@ -5,7 +5,7 @@ var router = require('express').Router();
 var participants = require('../service/participants');
 
 router.get('/', function (req, res) {
-    participants.getAll().then(function (result) {
+    participants.getAll(true).then(function (result) {
         return res.render('participants/list', {participants: result});
     });
 });

--- a/service/participants.js
+++ b/service/participants.js
@@ -6,12 +6,18 @@ var Q = require('q');
 
 var connectionString = process.env.SNAP_DB_PG_URL || process.env.DATABASE_URL || "tcp://vagrant@localhost/pace";
 
-function getAll() {
+function getAll(payment_status) {
+    if (payment_status != undefined){
+      var querystring='select * from participants where has_payed='+payment_status+' order by firstname,lastname';
+    } else {
+      var querystring='select * from participants order by firstname,lastname';
+    }
     var participants = [];
     var deferred = Q.defer();
 
     pg.connect(connectionString, function (err, client, done) {
-            var query = client.query('select * from participants order by firstname,lastname');
+            console.log(querystring);
+            var query = client.query(querystring);
             query.on('row', function (row) {
                 participants.push(row);
             });

--- a/service/participants.js
+++ b/service/participants.js
@@ -7,10 +7,11 @@ var Q = require('q');
 var connectionString = process.env.SNAP_DB_PG_URL || process.env.DATABASE_URL || "tcp://vagrant@localhost/pace";
 
 function getAll(payment_status) {
-    if (payment_status != undefined){
-      var querystring='select * from participants where has_payed='+payment_status+' order by firstname,lastname';
+    var querystring='';
+    if (payment_status !== undefined){
+      querystring='select * from participants where has_payed='+payment_status+' order by firstname,lastname';
     } else {
-      var querystring='select * from participants order by firstname,lastname';
+      querystring='select * from participants order by firstname,lastname';
     }
     var participants = [];
     var deferred = Q.defer();


### PR DESCRIPTION
store payment status in the database and only show
those records publicly, who have already payed.

the getAll() method now takes an optional argument and passes that directly to
the sql query. looks awful and should be fixed. I just don't know how.

See https://trello.com/c/fTbtjJGl/5-participants-list-public

And I couldn't write a functional test because the tests fail to run on my machine...