### PR TITLE
we need to be able to configure if pace is running behind a proxy

### DIFF
--- a/app.js
+++ b/app.js
@@ -30,6 +30,7 @@ app.set('views', path.join(__dirname, 'views'));
 app.set('view engine', 'jade');
 
 app.disable("x-powered-by");
+app.set('trust proxy',config.get('proxy'));
 
 app.use(favicon());
 app.use(logger('dev'));

--- a/config/default.json
+++ b/config/default.json
@@ -15,5 +15,6 @@
     "password": "Blanch4rdst0wn"
   },
   "cookie-secret":"change this in your local config",
+  "proxy":false,
   "https":false
 }


### PR DESCRIPTION
problem is, that we want to set the secure flag of
the cookies. but since the connection between pace and the
proxy is not encrypted, express does not set any cookie.
we need to be able to tell express that the connection is
encrypted but only beteen the proxy and the user.