### PR TITLE
fixed silently failing test

### DIFF
--- a/spec/adminJourney.js
+++ b/spec/adminJourney.js
@@ -129,6 +129,10 @@ describe('admin page', () => {
           lastName = _.isArray(lastNames) ? lastNames[0] : lastNames;
         })
         .click('a.edit-button')
+        .isVisible('#firstname')
+        .then(isVisible => {
+          expect(isVisible).toBe(true);
+        })
         .getValue('#firstname')
         .then(function (value) {
           expect(value).toBe(firstName);


### PR DESCRIPTION
we actually had a test for the functionality of edit participants as an admin, but it was just silently failing. getValue is not executing the callback if the element is just not there, so there is no expectation to fail. fixed with this update.

