### PR TITLE
the latest build of our vagrant base image change the credentials.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,11 @@ To look at the db in your terminal, just connect to the vagrant box (from the po
 ### If you really don't want to use vagrant
 it is possible to use docker instead. Run this to get the database up:
 
-`docker run -p 5432:5432 -d --name 'pace-postgres' -e POSTGRES_PASSWORD='pgtester' -e POSTGRES_DB='pace' -e POSTGRES_USER='pgtester' postgres`
+`docker run -p 5432:5432 -d --name 'pace-postgres' -e POSTGRES_PASSWORD='some_password' -e POSTGRES_DB='pace' -e POSTGRES_USER='pace' postgres`
+
+You have to set the DATABASE_URL to point to the non default db. Setting a environment variable is the easiest way:
+
+`export DATABASE_URL='postgres://pace:some_password@localhost/pace'`
 
 #### Starting
 Just run `gulp` and open http://localhost:3000 in your browser.

--- a/database.json
+++ b/database.json
@@ -1,5 +1,5 @@
 {
-  "dev": "postgres://pgtester:pgtester@localhost/pace",
+  "dev": "postgres://sa:vagrant@localhost/pace",
   "ci": {"ENV": "DATABASE_URL"},
   "prod": {"ENV": "DATABASE_URL"}
 }

--- a/postgres/Vagrantfile
+++ b/postgres/Vagrantfile
@@ -5,5 +5,5 @@ Vagrant.configure("2") do |config|
   config.vm.box = "wegtam/db-tester"
   config.vm.network :forwarded_port, guest: 5432, host: 5432
   config.vm.provision "shell",
-      inline: "su vagrant -c 'psql postgresql://pgtester:pgtester@localhost/postgres -c \"create database pace with owner=pgtester;\"'"
+      inline: "su vagrant -c 'psql postgresql://sa:vagrant@localhost/postgres -c \"create database pace with owner=sa;\"'"
 end

--- a/service/util/dbHelper.js
+++ b/service/util/dbHelper.js
@@ -5,7 +5,7 @@
 const pg = require('pg');
 const Q = require('q');
 
-const connectionString = process.env.SNAP_DB_PG_URL || process.env.DATABASE_URL || 'tcp://pgtester:pgtester@localhost/pace';
+const connectionString = process.env.SNAP_DB_PG_URL || process.env.DATABASE_URL || 'tcp://sa:vagrant@localhost/pace';
 
 let db = {};
 

--- a/spec/journeyHelper.js
+++ b/spec/journeyHelper.js
@@ -32,7 +32,7 @@ journeyHelper.resetToOriginalTimeout = function () {
 };
 
 journeyHelper.setupDbConnection = function (done) {
-  let connectionString = process.env.SNAP_DB_PG_URL || process.env.DATABASE_URL || 'tcp://pgtester:pgtester@localhost/pace';
+  let connectionString = process.env.SNAP_DB_PG_URL || process.env.DATABASE_URL || 'tcp://sa:vagrant@localhost/pace';
   let jasmineDone = done;
 
   pg.connect(connectionString, (err, client, done) => {


### PR DESCRIPTION
instead of pgtester:pgtester its now sa:vagrant.
Why sa? I really would like to drop vagrant support altogether...
I changed the documentation for docker because it does not make sense to use
the same credentials as vagrant anymore.