### PR TITLE
deploy to heroku

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,9 @@ script:
   - gulp test 
   - gulp test-integration
   - gulp test-functional
+deploy:
+  provider: heroku
+  app: dev-pace
+  run: 
+    - db-migrate -e prod -v up
+    - restart


### PR DESCRIPTION
missing: deploy key.
The owner of the heroku app has to create this by running:

  `travis encrypt $(heroku auth:token) --add deploy.api_key`