### PR TITLE
we need to run on node > 6.x even on heroku

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
     "start": "node ./bin/www",
     "test": "gulp test && gulp test-integration && gulp test-functional"
   },
+   "engines": {
+     "node": "6.1"
+  },
   "dependencies": {
     "body-parser": "~1.15.2",
     "config": "^1.24.0",


### PR DESCRIPTION
the only way to tell heroku to use a version is by
stating it in package.json